### PR TITLE
Add litepcie_gen wrapper and proFPGA VU19P configuration file

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LitePCIe.
+#
+# Copyright (c) 2019-2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+LitePCIE standalone core generator for proFPGA systems
+
+LitePCIe aims to be directly used as a python package when the SoC is created using LiteX. However,
+for some use cases it could be interesting to generate a standalone verilog file of the core:
+- integration of the core in a SoC using a more traditional flow.
+- need to version/package the core.
+- avoid Migen/LiteX dependencies.
+- etc...
+
+The standalone core is generated from a YAML configuration file that allows the user to generate
+easily a custom configuration of the core.
+"""
+
+import yaml
+import argparse
+import subprocess
+
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+
+from litepcie.software import generate_litepcie_software_headers
+
+from litepcie.gen import LitePCIeCore
+
+from litex.build.generic_platform import *
+
+def main():
+    parser = argparse.ArgumentParser(description="LitePCIe standalone core generator for proFPGA systems")
+    parser.add_argument("config", help="YAML config file")
+    parser.add_argument("--doc",  action="store_true", help="Build documentation")
+    args = parser.parse_args()
+    core_config = yaml.load(open(args.config).read(), Loader=yaml.Loader)
+
+    # Convert YAML elements to Python/LiteX --------------------------------------------------------
+    for k, v in core_config.items():
+        replaces = {"False": False, "True": True, "None": None}
+        for r in replaces.keys():
+            if v == r:
+                core_config[k] = replaces[r]
+
+    # Generate core --------------------------------------------------------------------------------
+    if core_config["phy"] == "USP19PPCIEPHY":
+        from litex.build.xilinx import XilinxPlatform
+        from litex_on_profpga_systems.pcie.usppciephy import USP19PPCIEPHY
+        platform = XilinxPlatform(core_config["phy_device"], io=[], toolchain="vivado")
+        core_config["phy"]           = USP19PPCIEPHY
+        core_config["qword_aligned"] = False
+        core_config["endianness"]    = "little"
+    else:
+        raise ValueError("Unsupported PCIe PHY: {}".format(core_config["phy"]))
+    soc      = LitePCIeCore(platform, core_config)
+    builder  = Builder(soc, output_dir="build", compile_gateware=False)
+    builder.build(build_name="litepcie_core", regular_comb=True)
+    generate_litepcie_software_headers(soc, "./")
+
+    if args.doc:
+        soc.generate_documentation("litepcie_core")
+
+if __name__ == "__main__":
+    main()

--- a/profpga_vu19p.yml
+++ b/profpga_vu19p.yml
@@ -1,0 +1,39 @@
+#
+# This file is part of LitePCIe.
+#
+# Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+{
+    # PHY ----------------------------------------------------------------------
+    "phy":                 "USP19PPCIEPHY", # Type of PCIe PHY
+    "phy_device":          "xcvu",          # Type of Device
+    "phy_speed":           "gen3",          # PCIe speed
+    "phy_lanes":           8,               # Number of lanes
+    "phy_pcie_data_width": 256,             # PCIe data_width
+    "phy_data_width":      256,             # Bus data_width
+    "phy_bar0_size":       0x40000,         # BAR0 size
+
+    # Clocking -----------------------------------------------------------------
+    "clk_freq":     150e6,                  # User Clk Freq (AXI MMAP/DMA)
+    "clk_external": True,                   # Use external User provided Clk
+
+    # MMAP Master --------------------------------------------------------------
+    "mmap":      True,
+    "mmap_base": 0x00020000,
+    "mmap_size": 0x00020000,
+
+    # MMAP Slave ---------------------------------------------------------------
+    "mmap_slave": True,
+
+    # DMA channels -------------------------------------------------------------
+    "dma_channels":     2,                  # Number of DMA channels
+    "dma_buffering":    1024,               # Buffering for each channel (in bytes)
+    "dma_loopback":     True,               # Enable DMA loopback capability
+    "dma_synchronizer": False,              # Enable DMA synchronizer capability
+    "dma_monitor":      False,              # Enable DMA monitoring capability
+
+    # MSI IRQs -----------------------------------------------------------------
+    "msi_irqs": 16,                         # Number or MSI IRQs
+}


### PR DESCRIPTION
This PR adds a small wrapper that utilizes target defined in `litepcie_gen` but allows to use PCIe PHYs that are defined in this repository.

This also includes a config for VU19P board.